### PR TITLE
StatefulSet config upgraded for Kubernetes 1.6-1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aerospike-kube
 
-This project contains the init container used in Kubernetes (k8s) and the aerospike petset definition
+This project contains the init container used in Kubernetes (k8s) and the aerospike StatefulSet definition
 
 ## Usage:
 
@@ -10,30 +10,40 @@ Build and push the aerospike-install container to the Docker registry of your ch
 
 Use the aerospike-install image as the init-container.
 
+**Kubernetes 1.8+ (StatefulSet)**
+
+Deploy your StatefulSet: `kubectl create -f aerospike-statefulset.yaml`
+
+**Kubernetes 1.5 (StatefulSet old format)**
+
+Deploy your StatefulSet: `kubectl create -f aerospike-statefulset.yaml``
+
+*note* The last commit of the old template format is `cff91c3`.  
+
+*note* PetSet, a k8s 1.3 alpha feature, is now StatefulSet, a 1.5 beta feature.
+
 **Kubernetes 1.3 (PetSet)**
 
 Deploy your PetSet: `kubectl create -f aerospike-petset.yaml`
 
-**Kubernetes 1.5 (StatefulSet)**
-
-Deploy your StatefulSet: `kubectl create -f aerospike-statefulset.yam`
-
-*note* PetSet, a k8s 1.3 alpha feature, is now StatefulSet, a 1.5 beta feature.
 
 
 ## Requirements
 
 * Kubernetes 1.3+ with alpha features (PetSet, init containers)   
 or  
-* Kubernetes 1.5+ with beta deatures (StatefulSet)
+* Kubernetes 1.5+ with beta features (StatefulSet)  
+or
+* Kubernetes 1.8+
 * Kubernetes DNS add-in
 
 
 ## Example
 
-In your kubernetes PetSet yaml:
+In your yaml:
 
 ```
+...
 spec:
   serviceName: "aerospike"
   replicas: 3
@@ -41,32 +51,17 @@ spec:
     metadata:
       labels:
         app: aerospike
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
-        pod.alpha.kubernetes.io/init-containers: '[
-          {
-             "name": "install",
-             "image": "<YOUR_DOCKER_REGISTRY>/aerospike-install",
-             "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-             "volumeMounts": [
-               {
-                 "name":"confdir",
-                 "mountPath": "/etc/aerospike"
-               }
-             ]
-          }
-        ]'
-...
+
+      initContainers:
+      -  name: aerospike-install
+         image: <YOUR_PRIVATE_REPO>/aerospike-install
+         volumeMounts:
+         - name: confdir
+           mountPath: /etc/aerospike
+         env:
+         - name: POD_NAMESPACE
+           valueFrom:
+             fieldRef:
+               fieldPath: metadata.namespace
+      ...
 ```
-
-

--- a/aerospike-statefulset.yaml
+++ b/aerospike-statefulset.yaml
@@ -15,7 +15,12 @@
 # the License.
 # ------------------------------------------------------------------------------
 
-
+# Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aerospike-cluster-1
+---
 # Headless service to provide DNS lookup
 apiVersion: v1
 kind: Service
@@ -24,6 +29,7 @@ metadata:
     # Required anootation so that an empty DNS record is created (instead of being unresolvable)
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   name: aerospike
+  namespace: aerospike-cluster-1
   labels:
       app: aerospike-server
 spec:
@@ -35,11 +41,12 @@ spec:
   selector:
     # Tells which pods are part of the DNS record
     app: aerospike
-----
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: aerospike
+  namespace: aerospike-cluster-1
 spec:
   serviceName: "aerospike"
   replicas: 3
@@ -47,33 +54,6 @@ spec:
     metadata:
       labels:
         app: aerospike
-      annotations:
-        # Do not wait on user acknowledgement for pod startup, default behavior in StatefulSet
-        # pod.alpha.kubernetes.io/initialized: "true"
-        # Init containers run on host before pod startup
-        pod.alpha.kubernetes.io/init-containers: '[
-          {
-             "name": "install",
-             "image": "my.docker.repo/kube/aerospike-install",
-             "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-             "volumeMounts": [
-               {
-                 "name":"confdir",
-                 "mountPath": "/etc/aerospike"
-               }
-             ]
-          }
-        ]'
     spec:
       terminationGracePeriodSeconds: 30
       containers:
@@ -91,7 +71,7 @@ spec:
               port: 3000
           initialDelaySeconds: 15
           timeoutSeconds: 1
-        volumeMounts: 
+        volumeMounts:
         - name: confdir
           mountPath: /etc/aerospike
         # Downward API:
@@ -108,6 +88,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+      initContainers:
+      - name: aerospike-install
+        image: danielcoman/aerospike-install
+        volumeMounts:
+        - name: confdir
+          mountPath: /etc/aerospike
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       volumes:
       - name: confdir
         emptyDir: {}


### PR DESCRIPTION
Annotations are no longer supported and must be converted to the PodSpec field.
Tested with latest minikube.
https://kubernetes.io/docs/concepts/workloads/pods/init-containers/