### PR TITLE
Set nsup-period using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export AEROSPIKE_NAMESPACE=test
 export AEROSPIKE_REPL=2
 export AEROSPIKE_MEM=1
 export AEROSPIKE_TTL=0
-export AEROSPIKE_NSUP=0 # if AEROSPIKE_TTL is not 0, AEROSPIKE_NSUP should not be 0.
+export AEROSPIKE_NSUP_PERIOD=0 # if AEROSPIKE_TTL is not 0, AEROSPIKE_NSUP_PERIOD should not be 0.
 ```
 
 All `AEROSPIKE_*` parameters except AEROSPIKE\_NODES, AEROSPIKE_MEM are optional. Default values are listed above.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export AEROSPIKE_NAMESPACE=test
 export AEROSPIKE_REPL=2
 export AEROSPIKE_MEM=1
 export AEROSPIKE_TTL=0
-export AEROSPIKE_NSUP=3600
+export AEROSPIKE_NSUP=0 # if AEROSPIKE_TTL is not 0, AEROSPIKE_NSUP should not be 0.
 ```
 
 All `AEROSPIKE_*` parameters except AEROSPIKE\_NODES, AEROSPIKE_MEM are optional. Default values are listed above.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aerospike-kubernetes
 
-This project uses Aerospike Server Community Edition. For Aerospike Server Enterprise Edition, please refer [aerospike/aerospike-kubernetes-enterprise](https://github.com/aerospike/aerospike-kubernetes-enterprise). 
+This project uses Aerospike Server Community Edition. For Aerospike Server Enterprise Edition, please refer [aerospike/aerospike-kubernetes-enterprise](https://github.com/aerospike/aerospike-kubernetes-enterprise).
 
 This project contains the init container used in Kubernetes (k8s) and the Aerospike StatefulSet definition.
 These manifests will allow you to deploy a fully formed Aerospike cluster in minutes.
@@ -24,6 +24,7 @@ export AEROSPIKE_NAMESPACE=test
 export AEROSPIKE_REPL=2
 export AEROSPIKE_MEM=1
 export AEROSPIKE_TTL=0
+export AEROSPIKE_NSUP=3600
 ```
 
 All `AEROSPIKE_*` parameters except AEROSPIKE\_NODES, AEROSPIKE_MEM are optional. Default values are listed above.

--- a/configs/aerospike.template.conf
+++ b/configs/aerospike.template.conf
@@ -18,7 +18,7 @@ logging {
 
 	# Send log messages to stdout
 	console {
-		context any info 
+		context any info
 	}
 }
 
@@ -65,6 +65,7 @@ namespace ${NAMESPACE} {
 	replication-factor ${REPL_FACTOR}
 	memory-size ${MEM_GB}G
 	default-ttl ${DEFAULT_TTL}
+	nsup-period ${NSUP_PERIOD}
 
 #	storage-engine memory
 
@@ -72,9 +73,8 @@ namespace ${NAMESPACE} {
 	# following lines instead.
 
 	storage-engine device {
-		file /opt/aerospike/data/${MY_POD_NAME}-${NAMESPACE}.dat 
+		file /opt/aerospike/data/${MY_POD_NAME}-${NAMESPACE}.dat
 		filesize ${MEM_GB}G
 		data-in-memory true # Store data in memory in addition to file.
 	}
 }
-

--- a/manifests/statefulset.yaml
+++ b/manifests/statefulset.yaml
@@ -80,7 +80,7 @@ spec:
         - name: DEFAULT_TTL
           value: "$AEROSPIKE_TTL"
         - name: NSUP_PERIOD
-          value: "$AEROSPIKE_NSUP"
+          value: "$AEROSPIKE_NSUP_PERIOD"
         # Downward API:
         - name: MY_POD_NAME
           valueFrom:

--- a/manifests/statefulset.yaml
+++ b/manifests/statefulset.yaml
@@ -81,7 +81,6 @@ spec:
           value: "$AEROSPIKE_TTL"
         - name: NSUP_PERIOD
           value: "$AEROSPIKE_NSUP"
-          # nsup-period
         # Downward API:
         - name: MY_POD_NAME
           valueFrom:

--- a/manifests/statefulset.yaml
+++ b/manifests/statefulset.yaml
@@ -79,6 +79,9 @@ spec:
           value: "$AEROSPIKE_MEM"
         - name: DEFAULT_TTL
           value: "$AEROSPIKE_TTL"
+        - name: NSUP_PERIOD
+          value: "$AEROSPIKE_NSUP"
+          # nsup-period
         # Downward API:
         - name: MY_POD_NAME
           valueFrom:

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@ RED='\033[0;31m'
 NC='\033[0m'
 GREEN='\033[0;32m'
 PINK='\033[0;35m'
-cat manifests/* | envsubst '$APP_NAME $NAMESPACE $AEROSPIKE_NODES $AEROSPIKE_NAMESPACE $AEROSPIKE_REPL $AEROSPIKE_MEM $AEROSPIKE_TTL $AEROSPIKE_NSUP' > expanded.yaml
+cat manifests/* | envsubst '$APP_NAME $NAMESPACE $AEROSPIKE_NODES $AEROSPIKE_NAMESPACE $AEROSPIKE_REPL $AEROSPIKE_MEM $AEROSPIKE_TTL $AEROSPIKE_NSUP_PERIOD' > expanded.yaml
 if [ $? != 0 ]; then printf "Creating ${PINK}expanded.yaml${NC} - ${RED}Failed${NC}\n\n"; else printf "Creating ${PINK}expanded.yaml${NC} - ${GREEN}Success${NC}\n\n"; fi
 kubectl create configmap aerospike-conf -n $NAMESPACE --from-file=configs/
 if [ $? != 0 ]; then printf "Creating ${PINK}ConfigMap${NC} object - ${RED}Failed${NC}\n\n"; else printf "Creating ${PINK}ConfigMap${NC} object - ${GREEN}Success${NC}\n\n"; fi

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@ RED='\033[0;31m'
 NC='\033[0m'
 GREEN='\033[0;32m'
 PINK='\033[0;35m'
-cat manifests/* | envsubst '$APP_NAME $NAMESPACE $AEROSPIKE_NODES $AEROSPIKE_NAMESPACE $AEROSPIKE_REPL $AEROSPIKE_MEM $AEROSPIKE_TTL' > expanded.yaml
+cat manifests/* | envsubst '$APP_NAME $NAMESPACE $AEROSPIKE_NODES $AEROSPIKE_NAMESPACE $AEROSPIKE_REPL $AEROSPIKE_MEM $AEROSPIKE_TTL $AEROSPIKE_NSUP' > expanded.yaml
 if [ $? != 0 ]; then printf "Creating ${PINK}expanded.yaml${NC} - ${RED}Failed${NC}\n\n"; else printf "Creating ${PINK}expanded.yaml${NC} - ${GREEN}Success${NC}\n\n"; fi
 kubectl create configmap aerospike-conf -n $NAMESPACE --from-file=configs/
 if [ $? != 0 ]; then printf "Creating ${PINK}ConfigMap${NC} object - ${RED}Failed${NC}\n\n"; else printf "Creating ${PINK}ConfigMap${NC} object - ${GREEN}Success${NC}\n\n"; fi


### PR DESCRIPTION
If AEROSPIKE_TTL is not zero,  aerospike pod does not start. This is because nsup-period is not set.

> If the value of default-ttl is non-zero and nsup-period is zero (the default), the Aerospike server will not start.

https://www.aerospike.com/docs/operations/configure/namespace/retention/#configuration-parameters

Therefore, I thought that nsup-period should also be set by environment variables.