### PR TITLE
Improvements

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -35,50 +35,22 @@ For Helm v2,
 helm install --name aerospike-release aerospike/aerospike --set dbReplicas=5
 ```
 
-### Test Output:
-
-```sh
-NAME:   aerospike-release
-LAST DEPLOYED: Fri Mar  6 15:50:33 2020
-NAMESPACE: default
-STATUS: DEPLOYED
-
-RESOURCES:
-==> v1/ConfigMap
-NAME                                            DATA   AGE
-aerospike-release-conf                          2      51m
-
-==> v1/Pod(related)
-NAME                                           READY   STATUS    RESTARTS   AGE
-pod/aerospike-release-aerospike-0              1/1     Running   0          49m
-pod/aerospike-release-aerospike-1              1/1     Running   0          49m
-pod/aerospike-release-aerospike-2              1/1     Running   0          48m
-
-==> v1/Service
-NAME                                             TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
-service/aerospike-release-aerospike              ClusterIP   None         <none>        3000/TCP   49m
-
-==> v1/StatefulSet
-NAME                                                      READY   AGE
-statefulset.apps/aerospike-release-aerospike              3/3     49m
-```
-
-```sh
-$ helm list
-NAME             	REVISION	UPDATED                 	STATUS  	CHART                     	APP VERSION	NAMESPACE
-aerospike-release	1       	Fri Mar  6 15:50:33 2020	DEPLOYED	aerospike-5.0.0             5.0.0.4   	default
-```
-
 ### Apply custom Aerospike configuration
 
-- To override the default `aerospike.template.conf`, set `confFilePath` to point to the custom `aerospike.conf` file or template.
+- To override the default `aerospike.template.conf`, set `aerospikeConfFile` to point to the custom `aerospike.conf` file or template.
 
-	> `confFilePath` should be a file path on helm "client" machine (where the user is running the command `helm install`).
+	> `aerospikeConfFile` should be a file path on helm "client" machine (where the user is running the command `helm install`).
 
-- `confFilePath` can be set using `--set-file` option,
+- `aerospikeConfFile` can be set using `--set-file` option,
 	```sh
 	helm install aerospike-release aerospike/aerospike \
-				 --set-file confFilePath=/tmp/aerospike_templates/aerospike.template.conf
+				 --set-file aerospikeConfFile=/tmp/aerospike_templates/aerospike.template.conf
+	```
+
+- Aerospike configuration file can also be passed in base64 encoded form. Use `aerospikeConfFileBase64` configuration to specify base64 encoded string of the Aerospike configuration file.
+	```sh
+	helm install aerospike-release aerospike/aerospike \
+				 --set aerospikeConfFileBase64=$(base64 /tmp/aerospike_templates/aerospike.template.conf)
 	```
 
 ### Storage configuration
@@ -303,13 +275,17 @@ helm install --name aerospike-release aerospike/aerospike \
 			 --set enableAerospikeMonitoring=true
 ```
 
-Use option `--set-file prometheus.aerospikeAlertRulesFilePath` to add a custom aerospike alert rules configuration file.
+Use option `--set-file prometheus.aerospikeAlertRulesFile` to add a custom aerospike alert rules configuration file.
 
-> `prometheus.aerospikeAlertRulesFilePath` should be a file path on helm "client" machine (where the user is running 'helm install')
+> `prometheus.aerospikeAlertRulesFile` should be a file path on helm "client" machine (where the user is running 'helm install')
 
-Use option `--set-file alertmanager.alertmanagerConfFilePath` to add an alertmanager configuration file.
+Aerospike alert rules file can also be passed in base64 encoded form. Use `prometheus.aerospikeAlertRulesFileBase64` configuration to specify base64 encoded string of the Aerospike alert rules file.
 
-> `alertmanager.alertmanagerConfFilePath` should be a file path on helm "client" machine (where the user is running 'helm install')
+Use option `--set-file alertmanager.alertmanagerConfFile` to add an alertmanager configuration file.
+
+> `alertmanager.alertmanagerConfFile` should be a file path on helm "client" machine (where the user is running 'helm install')
+
+Alertmanager configuration file can also be passed in base64 encoded form. Use `alertmanager.alertmanagerConfFileBase64` configuration to specify base64 encoded string of the alertmanager configuration file.
 
 Check the below [configuration section](#configuration) or [`values.yaml`](values.yaml) file for more details on configuration of the `Aerospike Prometheus Exporter`, `Prometheus`, `Grafana` and `Alertmanager`.
 
@@ -325,7 +301,7 @@ Check the below [configuration section](#configuration) or [`values.yaml`](value
 | `image.repository`                                    | Aerospike Server Docker Image                                                                                                                                                             | `aerospike/aerospike-server`                                                                                         |
 | `image.tag`                                           | Aerospike Server Docker Image Tag                                                                                                                                                         | `5.4.0.3`                                                                                                            |
 | `initImage.repository`                                | Aerospike Kubernetes Init Container Image                                                                                                                                                 | `aerospike/aerospike-kubernetes-init`                                                                                |
-| `initImage.tag`                                       | Aerospike Kubernetes Init Container Image Tag                                                                                                                                             | `latest`                                                                                                              |
+| `initImage.tag`                                       | Aerospike Kubernetes Init Container Image Tag                                                                                                                                             | `latest`                                                                                                             |
 | `autoGenerateNodeIds`                                 | Auto generate and assign node-id(s) based on Pod's Ordinal Index                                                                                                                          | `true`                                                                                                               |
 | `nodeIDPrefix`                                        | Node ID prefix                                                                                                                                                                            | `a`                                                                                                                  |
 | `aerospikeNamespace`                                  | Aerospike Namespace name                                                                                                                                                                  | `test`                                                                                                               |
@@ -336,6 +312,7 @@ Check the below [configuration section](#configuration) or [`values.yaml`](value
 | `aerospikeHeartbeatPort`                              | Aerospike TCP Hearbeat Port                                                                                                                                                               | `3002`                                                                                                               |
 | `aerospikeFabricPort`                                 | Aerospike TCP Fabric Port                                                                                                                                                                 | `3001`                                                                                                               |
 | `aerospikeInfoPort`                                   | Aerospike TCP Info Port                                                                                                                                                                   | `3003`                                                                                                               |
+| `args`                                                | Define additional arguments to be passed to the Aerospike container                                                                                                                       | `[]`                                                                                                                 |
 | `autoRolloutConfig`		   	                        | Rollout ConfigMap/Secrets changes on 'helm upgrade'    			                                                                                                                        | `false`					   	                                                                                       |
 | `hostNetwork.enabled`		 			                | Enable `hostNetwork`. Allows Pods to access host network.			                                                                                                                        | `false`					   	                                                                                       |
 | `hostNetwork.useExternalIP`		 			        | Allow applications to connect using external IP of the instances			                                                                                                                | `false`					   	                                                                                       |
@@ -360,9 +337,12 @@ Check the below [configuration section](#configuration) or [`values.yaml`](value
 | `resources`                                           | Resource configuration (`requests` and `limits`)                                                                                                                                          | `{}` (nil)                                                                                                           |
 | `podSecurityContext`                                  | Aerospike pod security context                                                                                                                                                            | `{}` (nil)                                                                                                           |
 | `securityContext`                                     | Aerospike container security context                                                                                                                                                      | `{}` (nil)                                                                                                           |
-| `confFilePath`                                        | Custom aerospike.conf file path on helm client machine (To be used during the runtime, `helm install` .. etc)                                                                             | `not defined`                                                                                                        |
-| `prometheus.aerospikeAlertRulesFilePath`              | Aerospike alert rules configuration file location on helm client machine (To be used during the runtime, `helm install` .. etc)                                                           | `not defined`                                                                                                        |
-| `alertmanager.alertmanagerConfFilePath`               | Alertmanager configuration file location on helm client machine (To be used during the runtime, `helm install` .. etc)                                                                    | `not defined`                                                                                                        |
+| `aerospikeConfFile`                                   | Custom aerospike.conf file path on helm client machine (To be used during the runtime, `helm install` .. etc)                                                                             | `not defined`                                                                                                        |
+| `aerospikeConfFileBase64`                             | Custom Aerospike configuration file as base64 encoded string                                                                                                                              | `"" (not defined)`                                                                                                   |
+| `prometheus.aerospikeAlertRulesFile`                  | Aerospike alert rules configuration file location on helm client machine (To be used during the runtime, `helm install` .. etc)                                                           | `not defined`                                                                                                        |
+| `prometheus.aerospikeAlertRulesFileBase64`            | Aerospike alert rules file as base64 encoded string                                                                                                                                       | `"" (not defined)`                                                                                                   |
+| `alertmanager.alertmanagerConfFile`                   | Alertmanager configuration file location on helm client machine (To be used during the runtime, `helm install` .. etc)                                                                    | `not defined`                                                                                                        |
+| `alertmanager.alertmanagerConfFileBase64`             | Alertmanager configuration file as base64 encoded string                                                                                                                                  | `"" (not defined)`                                                                                                   |
 | `enableAerospikePrometheusExporter` 	                | Enable Sidecar Aerospike Prometheus Exporter (only)                                                                                                                                       | `false`					   	                                                                                       |
 | `enableAerospikeMonitoring`		 	                | Enable Aerospike Monitoring - sidecar prometheus exporter, Prometheus, Grafana, Alertmanager stack                                                                                        | `false`					   	                                                                                       |
 | `exporter.repository`                                 | Aerospike prometheus exporter image repository                                                                                                                                            | `aerospike/aerospike-prometheus-exporter`                                                                            |

--- a/helm/files/alertmanager.yaml
+++ b/helm/files/alertmanager.yaml
@@ -1,5 +1,7 @@
 # This is an example alertmanager.yaml which sends alert notifications to a slack channel.
-# Use "--set-file alertmanager.alertmanagerConfFilePath=<ConfigFilePath>" during "helm install" or "helm upgrade" to use custom alertmanager.yaml.
+# Use "--set-file alertmanager.alertmanagerConfFile=<ConfigFilePath>" during "helm install" or "helm upgrade" to use custom alertmanager.yaml.
+# or,
+# Use "--set alertmanager.alertmanagerConfFileBase64=<base64-encoded-alertmanager-conf-file>" during "helm install" or "helm upgrade" to use custom alertmanager.yaml.
 
 global:
   slack_api_url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -10,12 +10,7 @@ Define aerospike.name
 Define aerospike.fullname
 */}}
 {{- define "aerospike.fullname" -}}
-{{- $name := default .Chart.Name -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/templates/alertmanager-configmap.yaml
+++ b/helm/templates/alertmanager-configmap.yaml
@@ -26,11 +26,34 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/component: alertmanager
 data:
+  # default alertmanager configuration file
   {{ if .Files.Get "files/alertmanager.yaml" }}
   alertmanager.yaml: {{ tpl (.Files.Get "files/alertmanager.yaml") . | quote }}
   {{ end }}
+
+  {{- if and .Values.alertmanager.alertmanagerConfFilePath .Values.alertmanager.alertmanagerConfFile }}
+  {{ fail "Both legacy(alertmanager.alertmanagerConfFilePath) and new(alertmanager.alertmanagerConfFile) are configured! Use only one!" }}
+  {{- end }}
+
+  {{- if and (or .Values.alertmanager.alertmanagerConfFilePath .Values.alertmanager.alertmanagerConfFile) (.Values.alertmanager.alertmanagerConfFileBase64) }}
+  {{ fail "Both alertmanager.alertmanagerConfFilePath/alertmanager.alertmanagerConfFile and alertmanager.alertmanagerConfFileBase64 are configured! Use only one!" }}
+  {{- end }}
+
+  # old config for alertmanager configuration file
   {{ if (.Values.alertmanager.alertmanagerConfFilePath) }}
   alertmanager.yaml: |-
     {{ .Values.alertmanager.alertmanagerConfFilePath | nindent 4 | trim }}
+  {{ end }}
+
+  # new config for alertmanager configuration file
+  {{ if (.Values.alertmanager.alertmanagerConfFile) }}
+  alertmanager.yaml: |-
+    {{ .Values.alertmanager.alertmanagerConfFile | nindent 4 | trim }}
+  {{ end }}
+
+  # alertmanager configuration file provided as base64 encoded string
+  {{ if (.Values.alertmanager.alertmanagerConfFileBase64) }}
+  alertmanager.yaml: |-
+    {{ .Values.alertmanager.alertmanagerConfFileBase64 | b64dec | nindent 4 | trim }}
   {{ end }}
 {{- end }}

--- a/helm/templates/alertmanager-statefulset.yaml
+++ b/helm/templates/alertmanager-statefulset.yaml
@@ -26,6 +26,10 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/component: alertmanager
     unique-app: {{ .Release.Name }}-alertmanager
+    {{- with .Values.alertmanager.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+  {{- with .Values.alertmanager.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-alertmanager-operated
   replicas: {{ .Values.alertmanager.replicas }}
@@ -34,15 +38,20 @@ spec:
     type: {{ .Values.alertmanager.updateStrategy.type }}
   revisionHistoryLimit: 10
   selector:
-    matchLabels: *Labels
+    matchLabels:
+      <<: *Labels
+      {{- with .Values.alertmanager.podLabels }}{{ toYaml . | nindent 6 }}{{ end }}
   template:
     metadata:
-      labels: *Labels
+      labels:
+        <<: *Labels
+        {{- with .Values.alertmanager.podLabels }}{{ toYaml . | nindent 8 }}{{ end }}
       annotations:
         {{- if .Values.autoRolloutConfig }}
         # TODO: Add an entry for secrets when used in future
         checksum/config: {{ include (print $.Template.BasePath "/alertmanager-configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- with .Values.alertmanager.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "aerospike.fullname" . }}{{ else }}{{ .Values.rbac.serviceAccountName }}{{ end }}
       {{- if eq .Values.alertmanager.antiAffinity "hard" }}
@@ -158,6 +167,9 @@ spec:
     - metadata:
         name: {{ .Values.alertmanager.persistenceStorage.name }}
         labels: *Labels
+        {{- with $.Values.alertmanager.annotations }}
+        annotations: {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         volumeMode: {{ .Values.alertmanager.persistenceStorage.volumeMode }}
         accessModes:

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -27,18 +27,35 @@ metadata:
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
 data:
-  # Use dynamically supplied aerospike.template.conf over the existing one.
+  # default aerospike configuration file
   {{ if .Files.Get "files/aerospike.template.conf" }}
   aerospike.template.conf: {{ tpl (.Files.Get "files/aerospike.template.conf") . | quote }}
   {{ end }}
+
+  {{- if and .Values.confFilePath .Values.aerospikeConfFile }}
+  {{ fail "Both legacy(confFilePath) and new(aerospikeConfFile) are configured! Use only one!" }}
+  {{- end }}
+
+  {{- if and (or .Values.confFilePath .Values.aerospikeConfFile) (.Values.aerospikeConfFileBase64) }}
+  {{ fail "Both confFilePath/aerospikeConfFile and aerospikeConfFileBase64 are configured! Use only one!" }}
+  {{- end }}
+
+  # old config for aerospike configuration file
   {{ if (.Values.confFilePath) }}
   aerospike.template.conf: |-
     {{ .Values.confFilePath | nindent 4 | trim }}
   {{ end }}
 
-  # Add on-start.sh script to configmap if available
-  {{ if .Files.Get "files/on-start.sh" }}
-  on-start.sh: {{ tpl (.Files.Get "files/on-start.sh") . | quote }}
+  # new config for aerospike configuration file
+  {{ if (.Values.aerospikeConfFile) }}
+  aerospike.template.conf: |-
+    {{ .Values.aerospikeConfFile | nindent 4 | trim }}
+  {{ end }}
+
+  # aerospike configuration file provided as base64 encoded string
+  {{ if (.Values.aerospikeConfFileBase64) }}
+  aerospike.template.conf: |-
+    {{ .Values.aerospikeConfFileBase64 | b64dec | nindent 4 | trim }}
   {{ end }}
 
   # Add aerospike-prometheus-exporter config template to config if monitoring is enabled and if the file is available

--- a/helm/templates/externalipservices.yaml
+++ b/helm/templates/externalipservices.yaml
@@ -68,6 +68,10 @@ metadata:
     app: {{ template "aerospike.name" $dot }}
     chart: {{ $.Chart.Name }}
     release: {{ $.Release.Name }}
+    {{- with $.Values.externalIPServices.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+  {{- with $.Values.externalIPServices.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   externalIPs:
     - {{ $ip := index $.Values.externalIPServices.externalIPEndpoints $podIndex }} {{ $ip.IP }}

--- a/helm/templates/grafana-statefulset.yaml
+++ b/helm/templates/grafana-statefulset.yaml
@@ -27,19 +27,28 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/component: grafana
     unique-app: {{ .Release.Name }}-grafana
+    {{- with .Values.grafana.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+  {{- with .Values.grafana.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-grafana
   replicas: {{ .Values.grafana.replicas }}
   selector:
-    matchLabels: *Labels
+    matchLabels:
+      <<: *Labels
+      {{- with .Values.grafana.podLabels }}{{ toYaml . | nindent 6 }}{{ end }}
   template:
     metadata:
-      labels: *Labels
+      labels:
+        <<: *Labels
+        {{- with .Values.grafana.podLabels }}{{ toYaml . | nindent 8 }}{{ end }}
       annotations:
         {{- if .Values.autoRolloutConfig }}
         # TODO: Add an entry for secrets when used in future
         checksum/config: {{ include (print $.Template.BasePath "/grafana-configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- with .Values.grafana.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "aerospike.fullname" . }}{{ else }}{{ .Values.rbac.serviceAccountName }}{{ end }}
       {{- if eq .Values.grafana.antiAffinity "hard" }}
@@ -184,6 +193,9 @@ spec:
     - metadata:
         name: {{ .Values.grafana.persistenceStorage.name }}
         labels: *Labels
+        {{- with $.Values.grafana.annotations }}
+        annotations: {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         volumeMode: {{ .Values.grafana.persistenceStorage.volumeMode }}
         accessModes:

--- a/helm/templates/loadbalancerservices.yaml
+++ b/helm/templates/loadbalancerservices.yaml
@@ -28,6 +28,14 @@ metadata:
     app: {{ template "aerospike.name" $dot }}
     chart: {{ $.Chart.Name }}
     release: {{ $.Release.Name }}
+    {{- if $.Values.loadBalancerServices.labels }}
+    {{- with $.Values.loadBalancerServices.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+    {{- end }}
+  {{- if $.Values.loadBalancerServices.annotations }}
+  {{- with $.Values.loadBalancerServices.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/helm/templates/nodeportservices.yaml
+++ b/helm/templates/nodeportservices.yaml
@@ -28,6 +28,14 @@ metadata:
     app: {{ template "aerospike.name" $dot }}
     chart: {{ $.Chart.Name }}
     release: {{ $.Release.Name }}
+    {{- if $.Values.nodePortServices.labels }}
+    {{- with $.Values.nodePortServices.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+    {{- end }}
+  {{- if $.Values.nodePortServices.annotations }}
+  {{- with $.Values.nodePortServices.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/helm/templates/prometheus-configmap.yaml
+++ b/helm/templates/prometheus-configmap.yaml
@@ -74,11 +74,34 @@ data:
           replacement: $1
           action: replace
 
+  # default aerospike alert rules file
   {{ if .Files.Get "files/aerospike_rules.yaml" }}
   aerospike_rules.yaml: {{ tpl (.Files.Get "files/aerospike_rules.yaml") . | quote }}
   {{ end }}
+
+  {{- if and .Values.prometheus.aerospikeAlertRulesFilePath .Values.prometheus.aerospikeAlertRulesFile }}
+  {{ fail "Both legacy(prometheus.aerospikeAlertRulesFilePath) and new(prometheus.aerospikeAlertRulesFile) are configured! Use only one!" }}
+  {{- end }}
+
+  {{- if and (or .Values.prometheus.aerospikeAlertRulesFilePath .Values.prometheus.aerospikeAlertRulesFile) (.Values.prometheus.aerospikeAlertRulesFileBase64) }}
+  {{ fail "Both prometheus.aerospikeAlertRulesFilePath/prometheus.aerospikeAlertRulesFile and prometheus.aerospikeAlertRulesFileBase64 are configured! Use only one!" }}
+  {{- end }}
+
+  # old config for aerospike alert rules file
   {{ if (.Values.prometheus.aerospikeAlertRulesFilePath) }}
   aerospike_rules.yaml: |-
     {{ .Values.prometheus.aerospikeAlertRulesFilePath | nindent 4 | trim }}
+  {{ end }}
+
+  # new config for aerospike alert rules file
+  {{ if (.Values.prometheus.aerospikeAlertRulesFile) }}
+  aerospike_rules.yaml: |-
+    {{ .Values.prometheus.aerospikeAlertRulesFile | nindent 4 | trim }}
+  {{ end }}
+
+  # aerospike alert rules file provided as base64 encoded string
+  {{ if (.Values.prometheus.aerospikeAlertRulesFileBase64) }}
+  aerospike_rules.yaml: |-
+    {{ .Values.prometheus.aerospikeAlertRulesFileBase64 | b64dec | nindent 4 | trim }}
   {{ end }}
 {{- end }}

--- a/helm/templates/prometheus-statefulset.yaml
+++ b/helm/templates/prometheus-statefulset.yaml
@@ -27,6 +27,10 @@ metadata:
     release: {{ .Release.Name }}
     app.kubernetes.io/component: prometheus
     unique-app: {{ .Release.Name }}-prometheus
+    {{- with .Values.prometheus.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+  {{- with .Values.prometheus.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-prometheus
   replicas: {{ .Values.prometheus.replicas }}
@@ -34,15 +38,20 @@ spec:
   updateStrategy:
     type: {{ .Values.prometheus.updateStrategy.type }}
   selector:
-    matchLabels: *Labels
+    matchLabels:
+      <<: *Labels
+      {{- with .Values.prometheus.podLabels }}{{ toYaml . | nindent 6 }}{{ end }}
   template:
     metadata:
-      labels: *Labels
+      labels:
+        <<: *Labels
+        {{- with .Values.prometheus.podLabels }}{{ toYaml . | nindent 8 }}{{ end }}
       annotations:
         {{- if .Values.autoRolloutConfig }}
         # TODO: Add an entry for secrets when used in future
         checksum/config: {{ include (print $.Template.BasePath "/prometheus-configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- with .Values.prometheus.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "aerospike.fullname" . }}{{ else }}{{ .Values.rbac.serviceAccountName }}{{ end }}
       {{- if eq .Values.prometheus.antiAffinity "hard" }}
@@ -164,6 +173,9 @@ spec:
     - metadata:
         name: {{ .Values.prometheus.persistenceStorage.name }}
         labels: *Labels
+        {{- with $.Values.prometheus.annotations }}
+        annotations: {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         volumeMode: {{ .Values.prometheus.persistenceStorage.volumeMode }}
         accessModes:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -41,5 +41,9 @@ spec:
   selector:
     # Tells which pods are part of the DNS record
     app: {{ template "aerospike.name" . }}
+    chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
+    unique-app: {{ .Release.Name }}-aerospike
+    {{- with .Values.labels }}{{ toYaml . | nindent 4 }}{{ end }}
+    {{- with .Values.podLabels }}{{ toYaml . | nindent 4 }}{{ end }}
 ---

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -35,10 +35,8 @@ spec:
   serviceName: {{ template "aerospike.fullname" . }}
   selector:
     matchLabels:
-      app: {{ template "aerospike.name" . }}
-      chart: {{ .Chart.Name }}
-      release: {{ .Release.Name }}
-      unique-app: {{ .Release.Name }}-aerospike
+      <<: *AerospikeDeploymentLabels
+      {{- with .Values.podLabels }}{{ toYaml . | nindent 6 }}{{ end }}
   replicas: {{ .Values.dbReplicas }}
   template:
     metadata:
@@ -47,7 +45,6 @@ spec:
         {{- with .Values.podLabels }}{{ toYaml . | nindent 8 }}{{ end }}
       annotations:
         {{- if .Values.autoRolloutConfig }}
-        # TODO: Add an entry for secrets when used in future
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
@@ -104,6 +101,9 @@ spec:
       containers:
       - name: aerospike
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- with .Values.args }}
+        args: {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
         ports:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -90,6 +90,9 @@ autoGenerateNodeIds: true
 ### Deployment specific configurations
 ### -----------------------------------
 
+# Arguments that are passed to the Aerospike container
+# args: []
+
 # Rollout ConfigMap/Secrets changes on 'helm upgrade'
 # Alternatively, use 'kubectl rollout restart'
 autoRolloutConfig: false
@@ -105,10 +108,19 @@ hostNetwork:
 nodePortServices:
   enabled: false
   useExternalIP: false
+  # Extra labels for the node port services (optional)
+  labels: {}
+  # Extra annotations for the node port services (optional)
+  annotations: {}
 
 # Enable LoadBalancer Services (Type: LoadBalancer) to expose aerospike statefulset (Use helm upgrade for scale up/down).
 loadBalancerServices:
   enabled: false
+  # Extra labels for the load balancer services (optional)
+  labels: {}
+  # Extra annotations for load balancer services (optional)
+  annotations: {}
+    # cloud.google.com/load-balancer-type: "Internal"
 
 # Enable external IP Services (Type: ClusterIP) to expose aerospike statefulset (Use helm upgrade for scale up/down)
 externalIPServices:
@@ -134,6 +146,10 @@ externalIPServices:
     #   Port: 8003
     # - IP: 10.160.15.217
     #   Port: 8004
+  # Extra labels for the external IP services (optional)
+  labels: {}
+  # Extra annotations for the external IP services (optional)
+  annotations: {}
 
 # Legacy network configurations (Don't worry, these are still supported)
 
@@ -254,17 +270,32 @@ podSecurityContext: {}
 # Aerospike container security context
 securityContext: {}
 
+# Aerospike configuration file as base64 encoded string
+# aerospikeConfFileBase64: <base64-encoded-aerospike-conf-file>
+
 ### -----------------------------------------------------------
 ### Dynamic configuration - Used during 'helm install...' etc.
 ### -----------------------------------------------------------
 
 # Aerospike Configuration file path on helm "client" machine (from where the user is running 'helm install')
+# (new config)
+# aerospikeConfFile:
+
+# (old config)
 # confFilePath:
 
 # (Only when enableAerospikeMonitoring = true) Aerospike alert rules configuration file path on helm "client" machine (from where the user is running 'helm install')
+# (new config)
+# prometheus.aerospikeAlertRulesFile:
+
+# (old config)
 # prometheus.aerospikeAlertRulesFilePath:
 
 # (Only when enableAerospikeMonitoring = true) Alertmanager configuration file path on helm "client" machine (from where the user is running 'helm install')
+# (new config)
+# alertmanager.alertmanagerConfFile:
+
+# (old config)
 # alertmanager.alertmanagerConfFilePath:
 
 
@@ -386,6 +417,16 @@ prometheus:
   # Node Selector (For Prometheus Pods)
   nodeSelector: {}
 
+  # Extra labels for the Prometheus StatefulSet
+  labels: {}
+  # Extra annotations for the Prometheus StatefulSet
+  annotations: {}
+
+  # Extra labels for the Prometheus pods
+  podLabels: {}
+  # Extra annotations for the Prometheus pods
+  podAnnotations: {}
+
   # Affinity / AntiAffinity configurations (For Prometheus Pods)
   # Setting 'antiAffinity' option will prevent two pods of the same release be scheduled on the same node.
   # 'antiAffinity' levels can be "off" (not set), "soft" (preferredDuringSchedulingIgnoredDuringExecution) and "hard" (requiredDuringSchedulingIgnoredDuringExecution)
@@ -404,7 +445,13 @@ prometheus:
     #         - gke-gke-blr-default-pool-06a23412-0dkt
 
   # Aerospike alert rules configuration file path on helm "client" machine (from where the user is running 'helm install')
+  # (new config)
+  # aerospikeAlertRulesFile:
+  # (old config)
   # aerospikeAlertRulesFilePath:
+
+  # Alert rules file as base64 encoded string
+  # aerospikeAlertRulesFileBase64:
 
 
 ### ----------------------
@@ -480,6 +527,16 @@ grafana:
 
   # Node Selector (For Grafana Pods)
   nodeSelector: {}
+
+  # Extra labels for the Grafana StatefulSet
+  labels: {}
+  # Extra annotations for the Grafana StatefulSet
+  annotations: {}
+
+  # Extra labels for the Grafana pods
+  podLabels: {}
+  # Extra annotations for the Grafana pods
+  podAnnotations: {}
 
   # Affinity / AntiAffinity configurations (For Grafana Pods)
   # Setting 'antiAffinity' option will prevent two pods of the same release be scheduled on the same node.
@@ -573,6 +630,16 @@ alertmanager:
   # Node Selector (For Alertmanager Pods)
   nodeSelector: {}
 
+  # Extra labels for the Alertmanager StatefulSet
+  labels: {}
+  # Extra annotations for the Alertmanager StatefulSet
+  annotations: {}
+
+  # Extra labels for the Alertmanager pods
+  podLabels: {}
+  # Extra annotations for the Alertmanager pods
+  podAnnotations: {}
+
   # Affinity / AntiAffinity configurations (For Alertmanager Pods)
   # Setting 'antiAffinity' option will prevent two pods of the same release be scheduled on the same node.
   # 'antiAffinity' levels can be "off" (not set), "soft" (preferredDuringSchedulingIgnoredDuringExecution) and "hard" (requiredDuringSchedulingIgnoredDuringExecution)
@@ -591,4 +658,10 @@ alertmanager:
     #         - gke-gke-blr-default-pool-06a23412-0dkt
 
   # Alertmanager configuration file path on helm "client" machine (from where the user is running 'helm install')
+  # (new config)
+  # alertmanagerConfFile:
+  # (old config)
   # alertmanagerConfFilePath:
+
+  # Alertmanager configuration file as base64 encoded string
+  # alertmanagerConfFileBase64:


### PR DESCRIPTION
- Allow specifying args for aerospike container
- Allow configuration of labels and annotations for services
- Pass feature key file as a base64 encoded string
- Pass aerospike configuration file as a base64 encoded string
- Configure labels, annotations for Prometheus, Alertmanager, Grafana statefulset and pods
- Pass Aerospike alert rules and Alertmanager configuration file as a base64 encoded string