### PR TITLE
Add limit/request for AS exporter (Helm chart)

### DIFF
--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -205,6 +205,8 @@ spec:
         ports:
         - containerPort: {{ .Values.exporter.agentBindPort | default 9145 }}
           name: exporter
+        resources:
+{{ toYaml .Values.AerospikePrometheusExporterResources | indent 10 }}
         volumeMounts:
         - name: apeconfdir
           mountPath: /etc/aerospike-prometheus-exporter

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -306,6 +306,13 @@ securityContext: {}
 # Enable Aerospike Prometheus Exporter ONLY - sidecar - aerospike prometheus exporter.
 # If enableAerospikeMonitoring is set to true, no need to set enableAerospikePrometheusExporter to true.
 enableAerospikePrometheusExporter: false
+AerospikePrometheusExporterResources: {}
+# limits:
+#   cpu: 1
+#   memory: 1Gi
+# requests:
+#   cpu: 1
+#   memory: 1Gi
 
 # Enable Aerospike Monitoring - sidecar prometheus exporter, Prometheus, Grafana, Alertmanager stack
 enableAerospikeMonitoring: false


### PR DESCRIPTION
If there is a resource limit in the namespace where the Aerospike operates, then a default value is set, which is usually very small. As a result, when the Aerospike is loaded, CPU throttling begins.